### PR TITLE
use auth without ssl by default

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -7,7 +7,7 @@ server {
         ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
 
         location /api/auth/ {
-                proxy_pass https://wazo-auth:9497;
+                proxy_pass http://wazo-auth:9497;
                 proxy_set_header    Host                $http_host;
                 proxy_set_header    X-Script-Name       /api/auth;
                 proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/31

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1689